### PR TITLE
Fix various errors in the new hisse code

### DIFF
--- a/R/geohisse.R
+++ b/R/geohisse.R
@@ -32,7 +32,7 @@ GeoHiSSE <- function(phy, data, f=c(1,1,1), turnover=c(1,2,3), eps=c(1,2), hidde
     
     setDTthreads(threads=dt.threads)
 
-    if(sann == FALSE & starting.vals == NULL){
+    if(sann == FALSE & is.null(starting.vals)){
         warning("You have chosen to rely on the internal starting points that generally work but does not guarantee finding the MLE.")
     }
 

--- a/R/geohisse.old.R
+++ b/R/geohisse.old.R
@@ -29,7 +29,7 @@ GeoHiSSE.old <- function(phy, data, f=c(1,1,1), speciation=c(1,2,3), extirpation
         
     }
     
-    if(sann == FALSE & starting.vals == NULL){
+    if(sann == FALSE & is.null(starting.vals)){
         warning("You have chosen to rely on the internal starting points that generally work but does not guarantee finding the MLE.")
     }
 

--- a/R/hisse.R
+++ b/R/hisse.R
@@ -37,7 +37,7 @@ hisse <- function(phy, data, f=c(1,1), turnover=c(1,2), eps=c(1,2), hidden.state
 
     setDTthreads(threads=dt.threads)
 
-    if(sann == FALSE & starting.vals == NULL){
+    if(sann == FALSE & is.null(starting.vals)){
         warning("You have chosen to rely on the internal starting points that generally work but does not guarantee finding the MLE.")
     }
 

--- a/R/hisse.R
+++ b/R/hisse.R
@@ -412,7 +412,7 @@ SingleChildProbHiSSE <- function(cache, pars, compD, compE, start.time, end.time
             prob.subtree.cal[9:16] <- cache$bad.likelihood
             return(prob.subtree.cal)
         }else{
-            prob.subtree.cal[5:8] <- cache$bad.likelihood
+            prob.subtree.cal[3:4] <- cache$bad.likelihood
             return(prob.subtree.cal)
         }
     }else{

--- a/R/hisse.old.R
+++ b/R/hisse.old.R
@@ -26,7 +26,7 @@ hisse.old <- function(phy, data, f=c(1,1), hidden.states=TRUE, turnover.anc=c(1,
         
     }
     
-    if(sann == FALSE & starting.vals == NULL){
+    if(sann == FALSE & is.null(starting.vals)){
         warning("You have chosen to rely on the internal starting points that generally work but does not guarantee finding the MLE.")
     }
 

--- a/R/misse.R
+++ b/R/misse.R
@@ -56,7 +56,7 @@ MiSSE <- function(phy, f=1, turnover=c(1,2), eps=c(1,2), fixed.eps=NULL, conditi
 
     setDTthreads(threads=dt.threads)
 
-    if(sann == FALSE & starting.vals == NULL){
+    if(sann == FALSE & is.null(starting.vals)){
         warning("You have chosen to rely on the internal starting points that generally work but does not guarantee finding the MLE.")
     }
 

--- a/R/muhisse.R
+++ b/R/muhisse.R
@@ -36,7 +36,7 @@ MuHiSSE <- function(phy, data, f=c(1,1,1,1), turnover=c(1,2,3,4), eps=c(1,2,3,4)
         f[which(f==0)] <- 1
     }
     
-    if(sann == FALSE & starting.vals == NULL){
+    if(sann == FALSE & is.null(starting.vals)){
         warning("You have chosen to rely on the internal starting points that generally work but does not guarantee finding the MLE.")
     }
 

--- a/vignettes/hisse-new-vignette.Rmd
+++ b/vignettes/hisse-new-vignette.Rmd
@@ -49,7 +49,7 @@ As with the original HiSSE implementation (see `hisse.old()`), the number of fre
 ```{r, eval=FALSE}
 turnover <- c(1,1)
 extinction.fraction <- c(1,1)
-f <- c(1,1,1,1)
+f <- c(1,1)
 ```
 
 Next, we have to set up a transition matrix. There is a function provided to make this easy, and allows users to customize the matrix to fit particular hypotheses. Be sure to look at the options on this function call, for allowing diagonals and for customizing the matrix when you have character independent model. 
@@ -71,7 +71,7 @@ If you wanted to set up a true BiSSE model, where the turnover rate parameters a
 ```{r, eval=FALSE}
 turnover <- c(1,2)
 extinction.fraction <- c(1,1)
-BiSSE <- hiSSE(phy=phy, data=sim.dat, f=f, turnover=turnover, 
+BiSSE <- hisse(phy=phy, data=sim.dat, f=f, turnover=turnover,
                      eps=extinction.fraction, hidden.states=FALSE, 
                      trans.rate=trans.rates.bisse)
 ```
@@ -97,7 +97,7 @@ print(trans.rate.hisse)
 Now, we can just plug these options into MuHiSSE:
 
 ```{r, eval=FALSE}
-HiSSE <- hisse(phy=phy, data=states.trans, f=f, turnover=turnover, 
+HiSSE <- hisse(phy=phy, data=sim.dat, f=f, turnover=turnover,
                      eps=extinction.fraction, hidden.states=TRUE, 
                      trans.rate=trans.rate.hisse)
 ```


### PR DESCRIPTION
The vignette published with hisse version 1.9.9 on CRAN doesn't work when run through R.

The first error is at 

```r
dull.null <- hisse(phy=phy, data=sim.dat, f=f, turnover=turnover, 
                     eps=extinction.fraction, hidden.states=FALSE, 
                     trans.rate=trans.rates.bisse)
```

which gives

```
Error in if (sann == FALSE & starting.vals == NULL) { : 
  argument is of length zero
```

I fixed all `NULL` comparisons to use `is.null(x)`.

---

The second error is:

```
Error in hisse(phy = phy, data = sim.dat, f = f, turnover = turnover,  : 
  The vector of sampling frequencies does not match the number of tips in the tree.
```

I updated the vignette code to set `f <- c(1,1)`.

---

The third error is:

```
Error in seq.default(1, nrow(tmp) - 1, 2) : wrong sign in 'by' argument
```

This is caused by a typo in `SingleChildProbHiSSE`. The vector `prob.subtree.cal` is of length 4, so assigning to indices 5 through 8 doesn't make sense. I corrected this to `3:4` to match values later in the function. (I note that `CurrentGenData` is of type `data.table, data.frame`, and transposes of these data types can be unpredictable, which is likely what generated the original error message)

