### PR TITLE
Fix error when `sann = FALSE`

### DIFF
--- a/R/hisse.R
+++ b/R/hisse.R
@@ -334,6 +334,7 @@ hisse <- function(phy, data, f=c(1,1), turnover=c(1,2), eps=c(1,2), hidden.state
         }
     }
     
+    sann.counts <- NULL
     if(sann == FALSE){
         if(bounded.search == TRUE){
             cat("Finished. Beginning bounded subplex routine...", "\n")


### PR DESCRIPTION
In hisse 2.1.6 (commit 5b252d3a19f59132256e79e34d16ae96188313d9), if simulated annealing is disabled when calling `hisse()`, the following error occurs:

```
Error in hisse(tree, trait, sann = FALSE, ...)  :
  object 'sann.counts' not found
```

This pull request fixes this by unconditionally initializing the `sann.counts` variable.